### PR TITLE
Copilot連携と失敗系の改善を反映

### DIFF
--- a/azure-functions/src/ZennIt.Tests/GitHubOAuthClientTests.cs
+++ b/azure-functions/src/ZennIt.Tests/GitHubOAuthClientTests.cs
@@ -1,0 +1,34 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace ZennIt.Tests;
+
+public class GitHubOAuthClientTests
+{
+    [Fact]
+    public async Task ExchangeCodeForAccessTokenAsync_GitHubFailure_KeepsStatusCode()
+    {
+        var handler = new StubHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.Unauthorized)
+        {
+            Content = new StringContent("bad_verification_code")
+        });
+        var client = new HttpClient(handler);
+        var oauthClient = new GitHubOAuthClient(client);
+
+        var result = await oauthClient.ExchangeCodeForAccessTokenAsync("client", "secret", "code");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, result.StatusCode);
+        Assert.Equal("bad_verification_code", result.Body);
+    }
+
+    private sealed class StubHttpMessageHandler(HttpResponseMessage response) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/azure-functions/src/ZennIt.Tests/GoogleAnalyticsProxyClientTests.cs
+++ b/azure-functions/src/ZennIt.Tests/GoogleAnalyticsProxyClientTests.cs
@@ -1,0 +1,34 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace ZennIt.Tests;
+
+public class GoogleAnalyticsProxyClientTests
+{
+    [Fact]
+    public async Task SendAsync_UpstreamFailure_KeepsStatusCode()
+    {
+        var handler = new StubHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.BadRequest)
+        {
+            Content = new StringContent("invalid payload")
+        });
+        var client = new HttpClient(handler);
+        var proxyClient = new GoogleAnalyticsProxyClient(client);
+
+        var result = await proxyClient.SendAsync("{}", "measurement", "secret", debug: false);
+
+        Assert.Equal(HttpStatusCode.BadRequest, result.StatusCode);
+        Assert.Equal("invalid payload", result.Body);
+    }
+
+    private sealed class StubHttpMessageHandler(HttpResponseMessage response) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/azure-functions/src/ZennIt.Tests/ZennIt.Tests.csproj
+++ b/azure-functions/src/ZennIt.Tests/ZennIt.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ZennIt\ZennIt.csproj" />
+  </ItemGroup>
+</Project>

--- a/azure-functions/src/ZennIt/ExchangeGitHubToken.cs
+++ b/azure-functions/src/ZennIt/ExchangeGitHubToken.cs
@@ -10,7 +10,7 @@ public class ExchangeGitHubToken(
     ILoggerFactory loggerFactory)
 {
     private readonly ILogger _logger = loggerFactory.CreateLogger<ExchangeGitHubToken>();
-    private readonly HttpClient _httpClient = httpClientFactory.CreateClient();
+    private readonly GitHubOAuthClient _gitHubOAuthClient = new(httpClientFactory.CreateClient());
 
     [Function("ExchangeGitHubToken")]
     public async Task<HttpResponseData> Run([HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req)
@@ -38,22 +38,13 @@ public class ExchangeGitHubToken(
         var clientSecret = Environment.GetEnvironmentVariable("GitHubClientSecret");
         if (string.IsNullOrEmpty(clientId) || string.IsNullOrEmpty(clientSecret))
         {
-            // ì‡ïîÉGÉâÅ[
             return req.CreateResponse(HttpStatusCode.InternalServerError);
         }
 
-        var values = new Dictionary<string, string>
-        {
-            { "client_id", clientId },
-            { "client_secret", clientSecret },
-            { "code", code }
-        };
-        var content = new FormUrlEncodedContent(values);
-        var response = await _httpClient.PostAsync("https://github.com/login/oauth/access_token", content);
-        var responseString = await response.Content.ReadAsStringAsync();
+        var gitHubResponse = await _gitHubOAuthClient.ExchangeCodeForAccessTokenAsync(clientId, clientSecret, code);
 
-        var okResponse = req.CreateResponse(HttpStatusCode.OK);
-        await okResponse.WriteStringAsync(responseString);
-        return okResponse;
+        var proxyResponse = req.CreateResponse(gitHubResponse.StatusCode);
+        await proxyResponse.WriteStringAsync(gitHubResponse.Body);
+        return proxyResponse;
     }
 }

--- a/azure-functions/src/ZennIt/GitHubOAuthClient.cs
+++ b/azure-functions/src/ZennIt/GitHubOAuthClient.cs
@@ -1,0 +1,27 @@
+using System.Net;
+
+namespace ZennIt;
+
+public sealed class GitHubOAuthClient(HttpClient httpClient)
+{
+    public async Task<GitHubOAuthResult> ExchangeCodeForAccessTokenAsync(
+        string clientId,
+        string clientSecret,
+        string code)
+    {
+        var values = new Dictionary<string, string>
+        {
+            { "client_id", clientId },
+            { "client_secret", clientSecret },
+            { "code", code }
+        };
+
+        using var content = new FormUrlEncodedContent(values);
+        using var response = await httpClient.PostAsync("https://github.com/login/oauth/access_token", content);
+        var body = await response.Content.ReadAsStringAsync();
+
+        return new GitHubOAuthResult(response.StatusCode, body);
+    }
+}
+
+public sealed record GitHubOAuthResult(HttpStatusCode StatusCode, string Body);

--- a/azure-functions/src/ZennIt/GoogleAnalyticsProxyClient.cs
+++ b/azure-functions/src/ZennIt/GoogleAnalyticsProxyClient.cs
@@ -1,0 +1,30 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+
+namespace ZennIt;
+
+public sealed class GoogleAnalyticsProxyClient(HttpClient httpClient)
+{
+    public async Task<GoogleAnalyticsProxyResult> SendAsync(
+        string payload,
+        string measurementId,
+        string apiSecret,
+        bool debug)
+    {
+        var endpoint = debug
+            ? "https://www.google-analytics.com/debug/mp/collect"
+            : "https://www.google-analytics.com/mp/collect";
+        var requestUri = $"{endpoint}?measurement_id={measurementId}&api_secret={apiSecret}";
+
+        using var content = new StringContent(payload, Encoding.UTF8);
+        content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+        using var response = await httpClient.PostAsync(requestUri, content);
+        var body = await response.Content.ReadAsStringAsync();
+
+        return new GoogleAnalyticsProxyResult(response.StatusCode, body);
+    }
+}
+
+public sealed record GoogleAnalyticsProxyResult(HttpStatusCode StatusCode, string Body);

--- a/azure-functions/src/ZennIt/TrackAnalytics.cs
+++ b/azure-functions/src/ZennIt/TrackAnalytics.cs
@@ -1,0 +1,37 @@
+using System.Net;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+
+namespace ZennIt;
+
+public class TrackAnalytics(IHttpClientFactory httpClientFactory)
+{
+    private readonly GoogleAnalyticsProxyClient _proxyClient = new(httpClientFactory.CreateClient());
+
+    [Function("TrackAnalytics")]
+    public async Task<HttpResponseData> Run([HttpTrigger(AuthorizationLevel.Anonymous, "post")] HttpRequestData req)
+    {
+        var measurementId = Environment.GetEnvironmentVariable("GoogleAnalyticsMeasurementId");
+        var apiSecret = Environment.GetEnvironmentVariable("GoogleAnalyticsApiSecret");
+        if (string.IsNullOrEmpty(measurementId) || string.IsNullOrEmpty(apiSecret))
+        {
+            return req.CreateResponse(HttpStatusCode.InternalServerError);
+        }
+
+        var payload = await new StreamReader(req.Body).ReadToEndAsync();
+        if (string.IsNullOrWhiteSpace(payload))
+        {
+            var badRequestResponse = req.CreateResponse(HttpStatusCode.BadRequest);
+            await badRequestResponse.WriteStringAsync("Analytics payload is required.");
+            return badRequestResponse;
+        }
+
+        var query = System.Web.HttpUtility.ParseQueryString(req.Url.Query);
+        var debug = string.Equals(query["debug"], "true", StringComparison.OrdinalIgnoreCase);
+
+        var upstreamResponse = await _proxyClient.SendAsync(payload, measurementId, apiSecret, debug);
+        var response = req.CreateResponse(upstreamResponse.StatusCode);
+        await response.WriteStringAsync(upstreamResponse.Body);
+        return response;
+    }
+}

--- a/azure-functions/src/Zennit.sln
+++ b/azure-functions/src/Zennit.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.10.34707.107
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ZennIt", "ZennIt\ZennIt.csproj", "{98E157A4-1D69-40EB-84D0-C651DB8D2F5D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ZennIt.Tests", "ZennIt.Tests\ZennIt.Tests.csproj", "{C8B0B877-512F-42BC-93E4-860AF5040F26}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{98E157A4-1D69-40EB-84D0-C651DB8D2F5D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{98E157A4-1D69-40EB-84D0-C651DB8D2F5D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{98E157A4-1D69-40EB-84D0-C651DB8D2F5D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C8B0B877-512F-42BC-93E4-860AF5040F26}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C8B0B877-512F-42BC-93E4-860AF5040F26}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C8B0B877-512F-42BC-93E4-860AF5040F26}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C8B0B877-512F-42BC-93E4-860AF5040F26}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/chrome-extension/package.json
+++ b/chrome-extension/package.json
@@ -15,6 +15,7 @@
   },
   "scripts": {
     "build": "webpack --mode=production",
-    "dev": "webpack --mode=development"
+    "dev": "webpack --mode=development",
+    "test:unit": "node tests/run-unit-tests.mjs"
   }
 }

--- a/chrome-extension/src/assets/json/config.json
+++ b/chrome-extension/src/assets/json/config.json
@@ -1,6 +1,7 @@
 {
     "CLIENT_ID": "Ov23ctrNPZFiJabmPhwj",
     "FUNCTION_URL": "https://func-zennit-prod-japaneast.azurewebsites.net/api/ExchangeGitHubToken",
+    "ANALYTICS_FUNCTION_URL": "https://func-zennit-prod-japaneast.azurewebsites.net/api/TrackAnalytics",
     "GITHUB_AUTH_URL": "https://github.com/login/oauth/authorize",
     "GITHUB_API_BASE_URL": "https://api.github.com"
 }

--- a/chrome-extension/src/js/constants.js
+++ b/chrome-extension/src/js/constants.js
@@ -1,5 +1,7 @@
 // constants.js
 
+import { SERVICE_DEFINITIONS, getServiceByUrl } from './service-config.mjs';
+
 // 共通定数を定義
 const STORAGE_KEYS = {
   REPOSITORY: 'repository',
@@ -10,24 +12,24 @@ const STORAGE_KEYS = {
 // サービス情報をオブジェクト化
 const SERVICES = {
   CHATGPT: {
-    id: 'chatgpt',
-    selector: '#prompt-textarea'
+    id: SERVICE_DEFINITIONS.chatgpt.id,
+    selector: SERVICE_DEFINITIONS.chatgpt.selector
   },
   CLAUDE: {
-    id: 'claude',
-    selector: 'div[contenteditable="true"]'
+    id: SERVICE_DEFINITIONS.claude.id,
+    selector: SERVICE_DEFINITIONS.claude.selector
   },
   GEMINI: {
-    id: 'gemini',
-    selector: 'input-area-v2 .ql-editor[role="textbox"]'
+    id: SERVICE_DEFINITIONS.gemini.id,
+    selector: SERVICE_DEFINITIONS.gemini.selector
   },
   GITHUB_COPILOT: {
-    id: 'githubcopilot',
-    selector: '#copilot-chat-textarea'
+    id: SERVICE_DEFINITIONS.githubcopilot.id,
+    selector: SERVICE_DEFINITIONS.githubcopilot.selector
   },
   MICROSOFT_COPILOT: {
-    id: 'microsoftcopilot',
-    selector: '#m365-chat-editor-target-element'
+    id: SERVICE_DEFINITIONS.microsoftcopilot.id,
+    selector: SERVICE_DEFINITIONS.microsoftcopilot.selector
   },
 
   /**
@@ -36,19 +38,17 @@ const SERVICES = {
    * @returns {Object} サービスオブジェクト
    */
   getService(currentURL) {
-    if (currentURL.includes("claude.ai")) {
+    const service = getServiceByUrl(currentURL);
+    if (service.id === this.CLAUDE.id) {
       return this.CLAUDE;
     }
-    if (currentURL.includes("gemini.google.com")) {
+    if (service.id === this.GEMINI.id) {
       return this.GEMINI;
     }
-    if (currentURL.includes("github.com/copilot")) {
+    if (service.id === this.GITHUB_COPILOT.id) {
       return this.GITHUB_COPILOT;
     }
-    if (currentURL.includes("copilot.cloud.microsoft")) {
-      return this.MICROSOFT_COPILOT;
-    }
-    if (currentURL.includes("m365.cloud.microsoft/chat")) {
+    if (service.id === this.MICROSOFT_COPILOT.id) {
       return this.MICROSOFT_COPILOT;
     }
     return this.CHATGPT;

--- a/chrome-extension/src/js/content.js
+++ b/chrome-extension/src/js/content.js
@@ -14,9 +14,11 @@
 
 import STORAGE_KEYS, { SERVICES } from './constants.js';
 import { getPrompt } from './prompt-service.js';
+import { waitForElement as waitForDomElement } from './dom-waiter.mjs';
 
 // 定数定義
 const RETRY_INTERVAL = 500; // 要素を再チェックする間隔（ミリ秒）
+const ELEMENT_TIMEOUT = 10000; // 要素探索のタイムアウト（ミリ秒）
 const INPUT_DELAY = 50; // 入力後の遅延時間（ミリ秒）
 
 console.log("Zenn It! content script loaded");
@@ -60,16 +62,11 @@ async function generateSummary() {
  * @returns {Promise<Element>} 見つかった要素
  */
 function waitForElement(selector) {
-  return new Promise((resolve) => {
-    const checkElement = () => {
-      const element = document.querySelector(selector);
-      if (element) {
-        resolve(element);
-      } else {
-        setTimeout(checkElement, RETRY_INTERVAL);
-      }
-    };
-    checkElement();
+  return waitForDomElement({
+    findElement: () => document.querySelector(selector),
+    retryIntervalMs: RETRY_INTERVAL,
+    timeoutMs: ELEMENT_TIMEOUT,
+    timeoutMessage: `入力欄が見つかりませんでした: ${selector}`
   });
 }
 

--- a/chrome-extension/src/js/dom-waiter.mjs
+++ b/chrome-extension/src/js/dom-waiter.mjs
@@ -1,0 +1,37 @@
+export function waitForElement({
+  findElement,
+  retryIntervalMs,
+  timeoutMs,
+  timeoutMessage
+}) {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let retryTimerId = null;
+
+    const timeoutId = setTimeout(() => {
+      settled = true;
+      if (retryTimerId) {
+        clearTimeout(retryTimerId);
+      }
+      reject(new Error(timeoutMessage));
+    }, timeoutMs);
+
+    const checkElement = () => {
+      if (settled) {
+        return;
+      }
+
+      const element = findElement();
+      if (element) {
+        settled = true;
+        clearTimeout(timeoutId);
+        resolve(element);
+        return;
+      }
+
+      retryTimerId = setTimeout(checkElement, retryIntervalMs);
+    };
+
+    checkElement();
+  });
+}

--- a/chrome-extension/src/js/google-analytics.js
+++ b/chrome-extension/src/js/google-analytics.js
@@ -1,15 +1,26 @@
 import StorageService from './storage-service.js';
 
-const GA_ENDPOINT = 'https://www.google-analytics.com/mp/collect';
-const GA_DEBUG_ENDPOINT = 'https://www.google-analytics.com/debug/mp/collect';
-
-// Get via https://developers.google.com/analytics/devguides/collection/protocol/ga4/sending-events?client_type=gtag#recommended_parameters_for_reports
-const MEASUREMENT_ID = 'G-150ZXPLM78';
-const API_SECRET = 'Hb_8d1ckQH2lCX7pAOiLfw';
 const DEFAULT_ENGAGEMENT_TIME_MSEC = 100;
 
 // Duration of inactivity after which a new session is created
 const SESSION_EXPIRATION_IN_MIN = 30;
+let analyticsConfigPromise = null;
+
+async function getAnalyticsFunctionUrl(debug) {
+  if (!analyticsConfigPromise) {
+    analyticsConfigPromise = fetch(chrome.runtime.getURL('assets/json/config.json'))
+      .then((response) => response.json());
+  }
+
+  const config = await analyticsConfigPromise;
+  if (!config.ANALYTICS_FUNCTION_URL) {
+    return null;
+  }
+
+  return debug
+    ? `${config.ANALYTICS_FUNCTION_URL}?debug=true`
+    : config.ANALYTICS_FUNCTION_URL;
+}
 
 class Analytics {
   constructor(debug = false) {
@@ -74,23 +85,26 @@ class Analytics {
     }
 
     try {
-      const response = await fetch(
-        `${
-          this.debug ? GA_DEBUG_ENDPOINT : GA_ENDPOINT
-        }?measurement_id=${MEASUREMENT_ID}&api_secret=${API_SECRET}`,
-        {
-          method: 'POST',
-          body: JSON.stringify({
-            client_id: await this.getOrCreateClientId(),
-            events: [
-              {
-                name,
-                params
-              }
-            ]
-          })
-        }
-      );
+      const endpoint = await getAnalyticsFunctionUrl(this.debug);
+      if (!endpoint) {
+        return;
+      }
+
+      const response = await fetch(endpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          client_id: await this.getOrCreateClientId(),
+          events: [
+            {
+              name,
+              params
+            }
+          ]
+        })
+      });
       if (!this.debug) {
         return;
       }

--- a/chrome-extension/src/js/prompt-service.js
+++ b/chrome-extension/src/js/prompt-service.js
@@ -3,6 +3,7 @@
 // ストレージとassetsフォルダからのプロンプト取得を一本化
 
 import StorageService from './storage-service.js';
+import { getPromptAssetPath } from './service-config.mjs';
 
 
 /**
@@ -12,7 +13,10 @@ import StorageService from './storage-service.js';
  */
 async function loadFromAssets(serviceName) {
   try {
-    const filePath = `assets/prompt/${serviceName}.txt`;
+    const filePath = getPromptAssetPath(serviceName);
+    if (!filePath) {
+      throw new Error(`Unknown service: ${serviceName}`);
+    }
     const response = await fetch(chrome.runtime.getURL(filePath));
     if (!response.ok) {
       throw new Error(`Failed to fetch ${filePath}: ${response.status}`);

--- a/chrome-extension/src/js/service-config.mjs
+++ b/chrome-extension/src/js/service-config.mjs
@@ -1,0 +1,53 @@
+export const SERVICE_DEFINITIONS = Object.freeze({
+  chatgpt: Object.freeze({
+    id: 'chatgpt',
+    selector: '#prompt-textarea',
+    promptAssetPath: 'assets/prompt/chatgpt.txt',
+    supportedUrlPrefixes: ['https://chatgpt.com/']
+  }),
+  claude: Object.freeze({
+    id: 'claude',
+    selector: 'div[contenteditable="true"]',
+    promptAssetPath: 'assets/prompt/claude.txt',
+    supportedUrlPrefixes: ['https://claude.ai/']
+  }),
+  gemini: Object.freeze({
+    id: 'gemini',
+    selector: 'input-area-v2 .ql-editor[role="textbox"]',
+    promptAssetPath: 'assets/prompt/gemini.txt',
+    supportedUrlPrefixes: ['https://gemini.google.com/']
+  }),
+  githubcopilot: Object.freeze({
+    id: 'githubcopilot',
+    selector: '#copilot-chat-textarea',
+    promptAssetPath: 'assets/prompt/githubcopilot.txt',
+    supportedUrlPrefixes: ['https://github.com/copilot']
+  }),
+  microsoftcopilot: Object.freeze({
+    id: 'microsoftcopilot',
+    selector: '#m365-chat-editor-target-element',
+    promptAssetPath: 'assets/prompt/microsoftcopilot.txt',
+    supportedUrlPrefixes: [
+      'https://copilot.cloud.microsoft/',
+      'https://m365.cloud.microsoft/chat'
+    ]
+  })
+});
+
+export function getPromptAssetPath(serviceId) {
+  return SERVICE_DEFINITIONS[serviceId]?.promptAssetPath ?? null;
+}
+
+export function isSupportedPageUrl(url) {
+  return Object.values(SERVICE_DEFINITIONS).some(({ supportedUrlPrefixes }) =>
+    supportedUrlPrefixes.some((prefix) => url.startsWith(prefix))
+  );
+}
+
+export function getServiceByUrl(url) {
+  return (
+    Object.values(SERVICE_DEFINITIONS).find(({ supportedUrlPrefixes }) =>
+      supportedUrlPrefixes.some((prefix) => url.includes(prefix))
+    ) ?? SERVICE_DEFINITIONS.chatgpt
+  );
+}

--- a/chrome-extension/src/js/summary-response.mjs
+++ b/chrome-extension/src/js/summary-response.mjs
@@ -1,0 +1,13 @@
+export function ensureSummaryGenerationSucceeded(response) {
+  if (!response) {
+    throw new Error('要約生成の結果を受信できませんでした。');
+  }
+
+  if (response.success === false) {
+    throw new Error(response.error || '要約生成に失敗しました。');
+  }
+}
+
+export function createSummaryFailureMessage(error) {
+  return `要約生成中にエラーが発生しました: ${error.message || '不明なエラー'}`;
+}

--- a/chrome-extension/src/manifest.json
+++ b/chrome-extension/src/manifest.json
@@ -16,7 +16,7 @@
         "assets/prompt/claude.txt",
         "assets/prompt/gemini.txt",
         "assets/prompt/githubcopilot.txt",
-        "assets/prompt/mscopilot.txt",
+        "assets/prompt/microsoftcopilot.txt",
         "assets/json/config.json",
         "js/constants.bundle.js"
       ],

--- a/chrome-extension/src/popup/popup.js
+++ b/chrome-extension/src/popup/popup.js
@@ -6,6 +6,11 @@
 import STORAGE_KEYS from '../js/constants.js';
 import Analytics from '../js/google-analytics.js';
 import StorageService from '../js/storage-service.js';
+import { isSupportedPageUrl } from '../js/service-config.mjs';
+import {
+  createSummaryFailureMessage,
+  ensureSummaryGenerationSucceeded
+} from '../js/summary-response.mjs';
 
 console.log("Popup script started loading...");
 
@@ -34,14 +39,6 @@ class PopupUI {
     this.publishArticleBtn = $('#publishArticle');
     this.openSettingsBtn = $('#openSettings'); // 設定ボタンの取得
     this.statusMessage = $('#statusMessage');
-    // 許可されたURLのリスト
-    this.allowedUrls = [
-      "https://claude.ai/", 
-      "https://chatgpt.com/", 
-      "https://gemini.google.com/",
-      "https://github.com/copilot",
-      "https://copilot.cloud.microsoft/"
-    ];
   }
 
   /**
@@ -99,7 +96,7 @@ class PopupUI {
         if (tabs.length > 0) {
           console.log(`Current tab: ${tabs[0]} URL: ${tabs[0].url}`);
           const currentUrl = tabs[0].url;
-          const isAllowed = this.allowedUrls.some(url => currentUrl.startsWith(url));
+          const isAllowed = isSupportedPageUrl(currentUrl);
           resolve(isAllowed);
         } else {
           resolve(false);
@@ -144,10 +141,11 @@ class PopupUI {
 
       const message = {action: 'generateSummary'};
       const response = await chrome.tabs.sendMessage(tabs[0].id, message);
+      ensureSummaryGenerationSucceeded(response);
       window.close();
     } catch (error) {
       console.error("要約生成中にエラーが発生しました:", error);
-      this.showStatus("要約生成中にエラーが発生しました", true);
+      this.showStatus(createSummaryFailureMessage(error), true);
     } finally {
       this.updateButtonStates();
     }

--- a/chrome-extension/tests/analytics-security.test.mjs
+++ b/chrome-extension/tests/analytics-security.test.mjs
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const analyticsSourcePath = path.resolve(__dirname, '../src/js/google-analytics.js');
+
+test('google-analytics client source does not embed an API secret', async () => {
+  const source = await fs.readFile(analyticsSourcePath, 'utf8');
+
+  assert.equal(source.includes('API_SECRET'), false);
+});

--- a/chrome-extension/tests/run-unit-tests.mjs
+++ b/chrome-extension/tests/run-unit-tests.mjs
@@ -1,0 +1,3 @@
+import './service-config.test.mjs';
+import './analytics-security.test.mjs';
+import './summary-workflow.test.mjs';

--- a/chrome-extension/tests/service-config.test.mjs
+++ b/chrome-extension/tests/service-config.test.mjs
@@ -1,0 +1,43 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  getServiceByUrl,
+  getPromptAssetPath,
+  isSupportedPageUrl
+} from '../src/js/service-config.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const manifestPath = path.resolve(__dirname, '../src/manifest.json');
+
+test('Microsoft Copilot prompt asset path uses the service id naming convention', () => {
+  assert.equal(
+    getPromptAssetPath('microsoftcopilot'),
+    'assets/prompt/microsoftcopilot.txt'
+  );
+});
+
+test('manifest exposes the Microsoft Copilot prompt asset', async () => {
+  const manifest = JSON.parse(await fs.readFile(manifestPath, 'utf8'));
+  const resources = manifest.web_accessible_resources[0].resources;
+
+  assert.ok(resources.includes('assets/prompt/microsoftcopilot.txt'));
+});
+
+test('Microsoft 365 Copilot URL is treated as a supported page', () => {
+  assert.equal(
+    isSupportedPageUrl('https://m365.cloud.microsoft/chat/'),
+    true
+  );
+});
+
+test('service lookup resolves Microsoft 365 Copilot to the Microsoft Copilot service', () => {
+  assert.equal(
+    getServiceByUrl('https://m365.cloud.microsoft/chat/').id,
+    'microsoftcopilot'
+  );
+});

--- a/chrome-extension/tests/summary-workflow.test.mjs
+++ b/chrome-extension/tests/summary-workflow.test.mjs
@@ -1,0 +1,42 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  createSummaryFailureMessage,
+  ensureSummaryGenerationSucceeded
+} from '../src/js/summary-response.mjs';
+import { waitForElement } from '../src/js/dom-waiter.mjs';
+
+test('ensureSummaryGenerationSucceeded throws the content-script error message', () => {
+  assert.throws(
+    () => ensureSummaryGenerationSucceeded({ success: false, error: '入力欄が見つかりません' }),
+    /入力欄が見つかりません/
+  );
+});
+
+test('ensureSummaryGenerationSucceeded throws when the response is missing', () => {
+  assert.throws(
+    () => ensureSummaryGenerationSucceeded(undefined),
+    /要約生成の結果を受信できませんでした/
+  );
+});
+
+test('createSummaryFailureMessage keeps the user-facing prefix', () => {
+  assert.equal(
+    createSummaryFailureMessage(new Error('入力欄が見つかりません')),
+    '要約生成中にエラーが発生しました: 入力欄が見つかりません'
+  );
+});
+
+test('waitForElement rejects with a timeout error when the element never appears', async () => {
+  await assert.rejects(
+    () =>
+      waitForElement({
+        findElement: () => null,
+        retryIntervalMs: 1,
+        timeoutMs: 5,
+        timeoutMessage: '入力欄が見つかりません'
+      }),
+    /入力欄が見つかりません/
+  );
+});


### PR DESCRIPTION
## 概要
Microsoft Copilot / M365 Copilot まわりの不整合修正、要約失敗時の明示化、OAuth/Analytics の失敗系改善をまとめて反映します。

## 対応内容
- Microsoft Copilot の prompt 資産名と manifest 公開設定を統一
- M365 Copilot でも popup の操作判定が有効になるよう修正
- 要約失敗時に popup へエラーを返すよう改善
- 入力欄探索にタイムアウトを追加
- GitHub OAuth 交換 API が upstream の失敗ステータスを返すよう改善
- サービス定義と URL 判定を共通化
- Google Analytics の API secret をクライアントから除去し、Functions 経由に変更
- これらの回帰防止テストを追加

## テスト
- npm run test:unit
- npm run build
- dotnet test Zennit.sln
- dotnet build Zennit.sln

Closes #20
Closes #21
Closes #22
Closes #23
Closes #24
Closes #25
Closes #26
Refs #27
