### PR TITLE
自動テストを強化する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,6 +151,7 @@ _TeamCity*
 coverage*.json
 coverage*.xml
 coverage*.info
+coverage-report*/
 
 # Visual Studio code coverage results
 *.coverage

--- a/azure-functions/src/ZennIt.Tests/FunctionHandlersTests.cs
+++ b/azure-functions/src/ZennIt.Tests/FunctionHandlersTests.cs
@@ -1,0 +1,121 @@
+using System.Net;
+using System.Security.Claims;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace ZennIt.Tests;
+
+public class FunctionHandlersTests
+{
+    [Fact]
+    public async Task ExchangeGitHubToken_Heartbeat_ReturnsOk()
+    {
+        var function = new ExchangeGitHubToken(new StubHttpClientFactory(HttpStatusCode.OK, "ignored"), NullLoggerFactory.Instance);
+        var request = CreateRequest("https://example.test/api/ExchangeGitHubToken?code=heartbeat", method: "GET");
+
+        var response = await function.Run(request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("I'm awake!", await ReadBodyAsync(response));
+    }
+
+    [Fact]
+    public async Task ExchangeGitHubToken_GitHubFailure_PropagatesStatusCode()
+    {
+        Environment.SetEnvironmentVariable("GitHubClientId", "client");
+        Environment.SetEnvironmentVariable("GitHubClientSecret", "secret");
+
+        var function = new ExchangeGitHubToken(new StubHttpClientFactory(HttpStatusCode.Unauthorized, "bad_verification_code"), NullLoggerFactory.Instance);
+        var request = CreateRequest("https://example.test/api/ExchangeGitHubToken?code=test-code", method: "GET");
+
+        var response = await function.Run(request);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.Equal("bad_verification_code", await ReadBodyAsync(response));
+    }
+
+    [Fact]
+    public async Task TrackAnalytics_EmptyPayload_ReturnsBadRequest()
+    {
+        Environment.SetEnvironmentVariable("GoogleAnalyticsMeasurementId", "measurement");
+        Environment.SetEnvironmentVariable("GoogleAnalyticsApiSecret", "secret");
+
+        var function = new TrackAnalytics(new StubHttpClientFactory(HttpStatusCode.OK, string.Empty));
+        var request = CreateRequest("https://example.test/api/TrackAnalytics", body: string.Empty);
+
+        var response = await function.Run(request);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("Analytics payload is required.", await ReadBodyAsync(response));
+    }
+
+    [Fact]
+    public async Task TrackAnalytics_UpstreamFailure_PropagatesStatusCode()
+    {
+        Environment.SetEnvironmentVariable("GoogleAnalyticsMeasurementId", "measurement");
+        Environment.SetEnvironmentVariable("GoogleAnalyticsApiSecret", "secret");
+
+        var function = new TrackAnalytics(new StubHttpClientFactory(HttpStatusCode.BadRequest, "invalid payload"));
+        var request = CreateRequest(
+            "https://example.test/api/TrackAnalytics?debug=true",
+            body: "{\"client_id\":\"test\"}");
+
+        var response = await function.Run(request);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("invalid payload", await ReadBodyAsync(response));
+    }
+
+    private static HttpRequestData CreateRequest(string url, string method = "POST", string body = "")
+    {
+        var functionContext = new Mock<FunctionContext>();
+        var response = CreateResponse(functionContext.Object);
+
+        var request = new Mock<HttpRequestData>(functionContext.Object);
+        request.SetupGet(x => x.Url).Returns(new Uri(url));
+        request.SetupGet(x => x.Method).Returns(method);
+        request.SetupGet(x => x.Headers).Returns(new HttpHeadersCollection());
+        request.SetupGet(x => x.Body).Returns(new MemoryStream(System.Text.Encoding.UTF8.GetBytes(body)));
+        request.SetupGet(x => x.Cookies).Returns(Array.Empty<IHttpCookie>());
+        request.SetupGet(x => x.Identities).Returns(Array.Empty<ClaimsIdentity>());
+        request.Setup(x => x.CreateResponse()).Returns(response.Object);
+
+        return request.Object;
+    }
+
+    private static Mock<HttpResponseData> CreateResponse(FunctionContext functionContext)
+    {
+        var response = new Mock<HttpResponseData>(functionContext);
+        response.SetupProperty(x => x.StatusCode, HttpStatusCode.OK);
+        response.SetupProperty(x => x.Headers, new HttpHeadersCollection());
+        response.SetupProperty(x => x.Body, new MemoryStream());
+        response.SetupGet(x => x.Cookies).Returns(new Mock<HttpCookies>().Object);
+        return response;
+    }
+
+    private static async Task<string> ReadBodyAsync(HttpResponseData response)
+    {
+        response.Body.Position = 0;
+        using var reader = new StreamReader(response.Body, leaveOpen: true);
+        return await reader.ReadToEndAsync();
+    }
+}
+
+internal sealed class StubHttpClientFactory(HttpStatusCode statusCode, string body) : IHttpClientFactory
+{
+    public HttpClient CreateClient(string name)
+    {
+        return CreateClient();
+    }
+
+    public HttpClient CreateClient()
+    {
+        return new HttpClient(new StubHttpMessageHandler(new HttpResponseMessage(statusCode)
+        {
+            Content = new StringContent(body)
+        }));
+    }
+}

--- a/azure-functions/src/ZennIt.Tests/GitHubOAuthClientTests.cs
+++ b/azure-functions/src/ZennIt.Tests/GitHubOAuthClientTests.cs
@@ -24,11 +24,4 @@ public class GitHubOAuthClientTests
         Assert.Equal("bad_verification_code", result.Body);
     }
 
-    private sealed class StubHttpMessageHandler(HttpResponseMessage response) : HttpMessageHandler
-    {
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            return Task.FromResult(response);
-        }
-    }
 }

--- a/azure-functions/src/ZennIt.Tests/GoogleAnalyticsProxyClientTests.cs
+++ b/azure-functions/src/ZennIt.Tests/GoogleAnalyticsProxyClientTests.cs
@@ -24,11 +24,4 @@ public class GoogleAnalyticsProxyClientTests
         Assert.Equal("invalid payload", result.Body);
     }
 
-    private sealed class StubHttpMessageHandler(HttpResponseMessage response) : HttpMessageHandler
-    {
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            return Task.FromResult(response);
-        }
-    }
 }

--- a/azure-functions/src/ZennIt.Tests/StubHttpMessageHandler.cs
+++ b/azure-functions/src/ZennIt.Tests/StubHttpMessageHandler.cs
@@ -1,0 +1,12 @@
+using System.Net.Http;
+using System.Threading;
+
+namespace ZennIt.Tests;
+
+internal sealed class StubHttpMessageHandler(HttpResponseMessage response) : HttpMessageHandler
+{
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        return Task.FromResult(response);
+    }
+}

--- a/azure-functions/src/ZennIt.Tests/ZennIt.Tests.csproj
+++ b/azure-functions/src/ZennIt.Tests/ZennIt.Tests.csproj
@@ -7,7 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/chrome-extension/src/js/analytics-request.mjs
+++ b/chrome-extension/src/js/analytics-request.mjs
@@ -1,0 +1,19 @@
+export function buildAnalyticsEndpoint(baseUrl, debug) {
+  if (!baseUrl) {
+    return null;
+  }
+
+  return debug ? `${baseUrl}?debug=true` : baseUrl;
+}
+
+export function buildAnalyticsBody(clientId, name, params) {
+  return JSON.stringify({
+    client_id: clientId,
+    events: [
+      {
+        name,
+        params
+      }
+    ]
+  });
+}

--- a/chrome-extension/src/js/google-analytics.js
+++ b/chrome-extension/src/js/google-analytics.js
@@ -1,4 +1,8 @@
 import StorageService from './storage-service.js';
+import {
+  buildAnalyticsBody,
+  buildAnalyticsEndpoint
+} from './analytics-request.mjs';
 
 const DEFAULT_ENGAGEMENT_TIME_MSEC = 100;
 
@@ -17,9 +21,7 @@ async function getAnalyticsFunctionUrl(debug) {
     return null;
   }
 
-  return debug
-    ? `${config.ANALYTICS_FUNCTION_URL}?debug=true`
-    : config.ANALYTICS_FUNCTION_URL;
+  return buildAnalyticsEndpoint(config.ANALYTICS_FUNCTION_URL, debug);
 }
 
 class Analytics {
@@ -95,15 +97,7 @@ class Analytics {
         headers: {
           'Content-Type': 'application/json'
         },
-        body: JSON.stringify({
-          client_id: await this.getOrCreateClientId(),
-          events: [
-            {
-              name,
-              params
-            }
-          ]
-        })
+        body: buildAnalyticsBody(await this.getOrCreateClientId(), name, params)
       });
       if (!this.debug) {
         return;

--- a/chrome-extension/tests/analytics-request.test.mjs
+++ b/chrome-extension/tests/analytics-request.test.mjs
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildAnalyticsBody,
+  buildAnalyticsEndpoint
+} from '../src/js/analytics-request.mjs';
+
+test('buildAnalyticsEndpoint appends the debug flag when needed', () => {
+  assert.equal(
+    buildAnalyticsEndpoint('https://example.test/api/TrackAnalytics', true),
+    'https://example.test/api/TrackAnalytics?debug=true'
+  );
+});
+
+test('buildAnalyticsEndpoint returns null without a base url', () => {
+  assert.equal(buildAnalyticsEndpoint('', false), null);
+});
+
+test('buildAnalyticsBody includes the client id, event name, and params', () => {
+  assert.deepEqual(
+    JSON.parse(buildAnalyticsBody('client-1', 'page_view', { session_id: '1' })),
+    {
+      client_id: 'client-1',
+      events: [
+        {
+          name: 'page_view',
+          params: { session_id: '1' }
+        }
+      ]
+    }
+  );
+});

--- a/chrome-extension/tests/run-unit-tests.mjs
+++ b/chrome-extension/tests/run-unit-tests.mjs
@@ -1,3 +1,4 @@
 import './service-config.test.mjs';
 import './analytics-security.test.mjs';
+import './analytics-request.test.mjs';
 import './summary-workflow.test.mjs';


### PR DESCRIPTION
## 概要
今回の改善に対する回帰防止テストを補強します。

## 対応内容
- Azure Functions のハンドラー本体テストを追加
- .NET テストプロジェクトに `coverlet.collector` と `Moq` を追加
- analytics 送信 payload/endpoint の組み立てをテスト可能な形に分離
- coverage レポート出力先を `.gitignore` に追加

## テスト
- npm run test:unit
- dotnet test Zennit.sln --collect:"XPlat Code Coverage"

Closes #28
Refs #27
