### PR TITLE
残る自動テストを補強する

### DIFF
--- a/azure-functions/src/ZennIt.Tests/CorsMiddlewareTests.cs
+++ b/azure-functions/src/ZennIt.Tests/CorsMiddlewareTests.cs
@@ -1,0 +1,28 @@
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Azure.Functions.Worker;
+using Moq;
+using Xunit;
+
+namespace ZennIt.Tests;
+
+public class CorsMiddlewareTests
+{
+    [Fact]
+    public async Task Invoke_SetsCorsHeadersOnResponseFeature()
+    {
+        Environment.SetEnvironmentVariable("AccessControlAllowOrigin", "chrome-extension://test");
+        var middleware = new CorsMiddleware();
+        var features = new TestInvocationFeatures();
+        var context = new Mock<FunctionContext>();
+        context.SetupGet(x => x.Features).Returns(features);
+
+        await middleware.Invoke(context.Object, _ => Task.CompletedTask);
+
+        var responseFeature = features.Get<IHttpResponseFeature>();
+        Assert.NotNull(responseFeature);
+        Assert.Equal("chrome-extension://test", responseFeature!.Headers["Access-Control-Allow-Origin"]);
+        Assert.Equal("GET, POST, OPTIONS", responseFeature.Headers["Access-Control-Allow-Methods"]);
+        Assert.Equal("*", responseFeature.Headers["Access-Control-Allow-Headers"]);
+        Assert.Equal("true", responseFeature.Headers["Access-Control-Allow-Credentials"]);
+    }
+}

--- a/azure-functions/src/ZennIt.Tests/TestInvocationFeatures.cs
+++ b/azure-functions/src/ZennIt.Tests/TestInvocationFeatures.cs
@@ -1,0 +1,33 @@
+using Microsoft.Azure.Functions.Worker;
+
+namespace ZennIt.Tests;
+
+internal sealed class TestInvocationFeatures : IInvocationFeatures
+{
+    private readonly Dictionary<Type, object> _features = new();
+
+    public void Set<T>(T instance)
+    {
+        _features[typeof(T)] = instance!;
+    }
+
+    public T? Get<T>()
+    {
+        if (_features.TryGetValue(typeof(T), out var instance))
+        {
+            return (T)instance;
+        }
+
+        return default;
+    }
+
+    public IEnumerator<KeyValuePair<Type, object>> GetEnumerator()
+    {
+        return _features.GetEnumerator();
+    }
+
+    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
+    }
+}

--- a/chrome-extension/src/js/content-dom-helpers.mjs
+++ b/chrome-extension/src/js/content-dom-helpers.mjs
@@ -1,0 +1,35 @@
+export async function simulateTypingIntoElement(element, text, {
+  createInputEvent,
+  delay
+}) {
+  if (element.tagName === 'TEXTAREA') {
+    element.value += text;
+  } else {
+    element.textContent += text;
+  }
+
+  element.dispatchEvent(createInputEvent('input', {
+    inputType: 'insertText',
+    data: text,
+    bubbles: true,
+    cancelable: true
+  }));
+
+  await delay();
+}
+
+export async function pressEnterIntoElement(element, {
+  createKeyboardEvent,
+  createEvent
+}) {
+  element.dispatchEvent(createKeyboardEvent('keydown', {
+    bubbles: true,
+    cancelable: true,
+    key: 'Enter',
+    keyCode: 13
+  }));
+
+  element.textContent += '\n';
+  element.dispatchEvent(createEvent('input', { bubbles: true }));
+  await Promise.resolve();
+}

--- a/chrome-extension/src/js/content.js
+++ b/chrome-extension/src/js/content.js
@@ -14,6 +14,10 @@
 
 import STORAGE_KEYS, { SERVICES } from './constants.js';
 import { getPrompt } from './prompt-service.js';
+import {
+  pressEnterIntoElement,
+  simulateTypingIntoElement
+} from './content-dom-helpers.mjs';
 import { waitForElement as waitForDomElement } from './dom-waiter.mjs';
 
 // 定数定義
@@ -90,27 +94,10 @@ async function inputPrompt(inputArea, service) {
  * @param {string} text - 入力するテキスト
  */
 async function simulateTyping(element, text) {
-  // textareaの場合はvalueを使う
-  if (element.tagName === 'TEXTAREA') {
-    element.value += text;
-    const event = new InputEvent('input', {
-      inputType: 'insertText',
-      data: text,
-      bubbles: true,
-      cancelable: true,
-    });
-    element.dispatchEvent(event);
-  } else {
-    element.textContent += text;
-    const event = new InputEvent('input', {
-      inputType: 'insertText',
-      data: text,
-      bubbles: true,
-      cancelable: true,
-    });
-    element.dispatchEvent(event);
-  }
-  await new Promise(resolve => setTimeout(resolve, INPUT_DELAY));
+  await simulateTypingIntoElement(element, text, {
+    createInputEvent: (type, init) => new InputEvent(type, init),
+    delay: () => new Promise(resolve => setTimeout(resolve, INPUT_DELAY))
+  });
 }
 
 /**
@@ -118,14 +105,8 @@ async function simulateTyping(element, text) {
  * @param {Element} element - 対象の要素
  */
 async function pressEnter(element) {
-  const enterEvent = new KeyboardEvent('keydown', {
-    bubbles: true,
-    cancelable: true,
-    key: 'Enter',
-    keyCode: 13
+  await pressEnterIntoElement(element, {
+    createKeyboardEvent: (type, init) => new KeyboardEvent(type, init),
+    createEvent: (type, init) => new Event(type, init)
   });
-  element.dispatchEvent(enterEvent);
-  element.textContent += '\n';
-  element.dispatchEvent(new Event('input', { bubbles: true }));
-  await Promise.resolve();
 }

--- a/chrome-extension/src/js/popup-status.mjs
+++ b/chrome-extension/src/js/popup-status.mjs
@@ -1,0 +1,11 @@
+export function applyStatusToElement(element, message, isError = false) {
+  element.textContent = message;
+  element.classList.toggle('error', isError);
+  element.hidden = false;
+}
+
+export function clearStatusElement(element) {
+  element.hidden = true;
+  element.classList.toggle('error', false);
+  element.textContent = '';
+}

--- a/chrome-extension/src/popup/popup.js
+++ b/chrome-extension/src/popup/popup.js
@@ -6,6 +6,10 @@
 import STORAGE_KEYS from '../js/constants.js';
 import Analytics from '../js/google-analytics.js';
 import StorageService from '../js/storage-service.js';
+import {
+  applyStatusToElement,
+  clearStatusElement
+} from '../js/popup-status.mjs';
 import { isSupportedPageUrl } from '../js/service-config.mjs';
 import {
   createSummaryFailureMessage,
@@ -111,9 +115,7 @@ class PopupUI {
    * @param {boolean} isError エラーメッセージの場合はtrue
    */
   showStatus(message, isError = false) {
-    this.statusMessage.textContent = message;
-    this.statusMessage.classList.toggle('error', isError);
-    this.statusMessage.hidden = false;
+    applyStatusToElement(this.statusMessage, message, isError);
   }
 
   /**
@@ -121,9 +123,7 @@ class PopupUI {
    * メッセージを非表示にし、内容をクリアします
    */
   clearStatus() {
-    this.statusMessage.hidden = true;
-    this.statusMessage.classList.toggle('error', false);
-    this.statusMessage.textContent = '';
+    clearStatusElement(this.statusMessage);
   }
 
   /**

--- a/chrome-extension/tests/content-dom-helpers.test.mjs
+++ b/chrome-extension/tests/content-dom-helpers.test.mjs
@@ -1,0 +1,67 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  pressEnterIntoElement,
+  simulateTypingIntoElement
+} from '../src/js/content-dom-helpers.mjs';
+
+test('simulateTypingIntoElement appends text to textarea value and dispatches input', async () => {
+  const events = [];
+  const element = {
+    tagName: 'TEXTAREA',
+    value: 'hello ',
+    dispatchEvent(event) {
+      events.push(event);
+    }
+  };
+
+  await simulateTypingIntoElement(element, 'world', {
+    createInputEvent: (type, init) => ({ type, ...init }),
+    delay: async () => {}
+  });
+
+  assert.equal(element.value, 'hello world');
+  assert.equal(events.length, 1);
+  assert.equal(events[0].type, 'input');
+  assert.equal(events[0].data, 'world');
+});
+
+test('simulateTypingIntoElement appends text to non-textarea textContent', async () => {
+  const events = [];
+  const element = {
+    tagName: 'DIV',
+    textContent: 'hello ',
+    dispatchEvent(event) {
+      events.push(event);
+    }
+  };
+
+  await simulateTypingIntoElement(element, 'world', {
+    createInputEvent: (type, init) => ({ type, ...init }),
+    delay: async () => {}
+  });
+
+  assert.equal(element.textContent, 'hello world');
+  assert.equal(events[0].type, 'input');
+});
+
+test('pressEnterIntoElement dispatches keydown and trailing input event', async () => {
+  const events = [];
+  const element = {
+    textContent: 'before',
+    dispatchEvent(event) {
+      events.push(event);
+    }
+  };
+
+  await pressEnterIntoElement(element, {
+    createKeyboardEvent: (type, init) => ({ type, ...init }),
+    createEvent: (type, init) => ({ type, ...init })
+  });
+
+  assert.equal(element.textContent, 'before\n');
+  assert.equal(events[0].type, 'keydown');
+  assert.equal(events[0].key, 'Enter');
+  assert.equal(events[1].type, 'input');
+});

--- a/chrome-extension/tests/popup-status.test.mjs
+++ b/chrome-extension/tests/popup-status.test.mjs
@@ -1,0 +1,48 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  applyStatusToElement,
+  clearStatusElement
+} from '../src/js/popup-status.mjs';
+
+function createStatusElement() {
+  const classes = new Set();
+  return {
+    hidden: true,
+    textContent: '',
+    classList: {
+      toggle(name, enabled) {
+        if (enabled) {
+          classes.add(name);
+        } else {
+          classes.delete(name);
+        }
+      },
+      contains(name) {
+        return classes.has(name);
+      }
+    }
+  };
+}
+
+test('applyStatusToElement shows the message and toggles error class', () => {
+  const element = createStatusElement();
+
+  applyStatusToElement(element, '失敗しました', true);
+
+  assert.equal(element.hidden, false);
+  assert.equal(element.textContent, '失敗しました');
+  assert.equal(element.classList.contains('error'), true);
+});
+
+test('clearStatusElement hides the message and removes error class', () => {
+  const element = createStatusElement();
+  applyStatusToElement(element, '失敗しました', true);
+
+  clearStatusElement(element);
+
+  assert.equal(element.hidden, true);
+  assert.equal(element.textContent, '');
+  assert.equal(element.classList.contains('error'), false);
+});

--- a/chrome-extension/tests/run-unit-tests.mjs
+++ b/chrome-extension/tests/run-unit-tests.mjs
@@ -1,4 +1,6 @@
 import './service-config.test.mjs';
 import './analytics-security.test.mjs';
 import './analytics-request.test.mjs';
+import './content-dom-helpers.test.mjs';
+import './popup-status.test.mjs';
 import './summary-workflow.test.mjs';


### PR DESCRIPTION
## 概要
未テストだった middleware と UI 入力補助の回帰防止テストを追加します。

## 対応内容
- `CorsMiddleware` の CORS ヘッダ付与テストを追加
- content script の DOM 入力 helper を切り出してテスト追加
- popup のステータス表示 helper を切り出してテスト追加
- 既存コードを helper 利用に整理

## テスト
- npm run test:unit
- npm run build
- dotnet test Zennit.sln
- dotnet build Zennit.sln

Closes #34
Refs #35
